### PR TITLE
Plentico www - Editorial suggestion for the use of "type"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public
 node_modules
+.DS_Store

--- a/content/docs/build.json
+++ b/content/docs/build.json
@@ -10,7 +10,7 @@
                     "p": [
                         "The build command creates the static assets that can be deployed to hosting provider.",
                         "It contains the generated Svelte code that hydrates into a Single Page Application (SPA),",
-                        "As well as the HTML fallbacks that allow you to navigate the site without JavaScript enabled,",
+                        "as well as the HTML fallbacks that allow you to navigate the site without JavaScript enabled,",
                         "improve Search Engine Optimization (SEO), and speed up the initial page load of your app."
                     ]
                 }

--- a/content/docs/eject.json
+++ b/content/docs/eject.json
@@ -8,11 +8,11 @@
             "body": [
                 {
                     "p": [
-                        "Ejecting is the process of exporting core files so you can customize what plenti uses in the background to generate your site.",
+                        "Ejecting is the process of exporting core files so you can customize what Plenti uses in the background to generate your site.",
                         "This functionality is generally reserved for experienced users that have a specific use",
                         "case for why the need to do this. If you want to customize your experience this way, just keep",
                         "in mind that you will no longer receive automatic updates for the ejected project and we can't",
-                        "gaurantee that your site will continue to work properly."
+                        "guarantee that your site will continue to work properly."
                     ]
                 }
             ]

--- a/content/docs/index.json
+++ b/content/docs/index.json
@@ -9,11 +9,11 @@
                 {
                     "p": [
                         "Plenti is an open source Static Site Generator (SSG).",
-                        "The templates are based on Svelte, which is a javascript library for building reactive user interfaces.",
-                        "Because Svelte is compiled, your app stays very light and performance well, even on underpowered devices.",
-                        "You might also notice that Plenti runs significantly faster than other Javascript SSGs you may have tried.",
+                        "The templates are based on Svelte, which is a JavaScript library for building reactive user interfaces.",
+                        "Because Svelte is compiled, your app stays very light and performs well, even on underpowered devices.",
+                        "You might also notice that Plenti runs significantly faster than other JavaScript SSGs you may have tried.",
                         "This is because the commandline interface (CLI) is built using Go and we've cut out slow processes like traditional bundlers.",
-                        "Our goal is to keep the tooling to a minimal so it's easy to install and use."
+                        "Our goal is to keep the tooling to a minimum so it's easy to install and use."
                     ]
                 }
             ]
@@ -29,7 +29,7 @@
                         "We think the missing piece that will open up the JAMstack to the masses is an integrated, Git-backed CMS.",
                         "In order to take advantage of this, we needed both a fast build and a reactive frontend that can connect to a Git repository.",
                         "That's why we're obsessing over speed (we're actively trying to make the builds even faster).",
-                        "We also use a simple JSON data source instead of markdown, because we don't intend for you to edit content directly through files.",
+                        "We also use a simple JSON data source instead of Markdown, because we don't intend for you to edit content directly through files.",
                         "We expect this will be done completely through the website user interface. It should also require minimum setup.",
                         "There are no shortage of excellent headless CMS options on the market for JAMstack, but most require purchasing a license for",
                         "a proprietary product, take significant developer time to connect to your website, lack on features like live displays,",

--- a/content/docs/layout.json
+++ b/content/docs/layout.json
@@ -8,9 +8,9 @@
             "body": [
                 {
                     "p": [
-                        "All the templating is done in \"disappearing\" JS component framework called <a href='https://svelte.dev/'>Svelte</a>.",
+                        "All the templating is done in the \"disappearing\" JS component framework called <a href='https://svelte.dev/'>Svelte</a>.",
                         "Svelte offers a simplified syntax and creates a welcoming developer experience for folks coming directly from an HTML/CSS background.",
-                        "It also offers some performance benefits over similar frameworks since it doesn't require a virtual dom and its runtime is rather small."
+                        "It also offers some performance benefits over similar frameworks since it doesn't require a virtual DOM and its runtime is rather small."
                     ]
                 }
             ]

--- a/content/docs/layout.json
+++ b/content/docs/layout.json
@@ -32,9 +32,9 @@
             "body": [
                 {
                     "p": [
-                        "Files that live in this folder correspond directly to the Types defined in your content source.",
-                        "For example if you have blog Type (<code>content/blog/post-whatever.json</code>) you would create a corresponding template at <code>layout/content/blog.svelte</code>.",
-                        "One template should be used per Type and it will feed many content files to create individual nodes (endpoints)."
+                        "Files that live in this folder correspond directly to the types defined in your content source.",
+                        "For example if you have <em>blog</em> type (<code>content/blog/post-whatever.json</code>) you would create a corresponding template at <code>layout/content/blog.svelte</code>.",
+                        "One template should be used per type and it will feed many content files to create individual nodes (endpoints)."
                     ]
                 },
                 {

--- a/content/docs/new_type.json
+++ b/content/docs/new_type.json
@@ -9,8 +9,8 @@
                 {
                     "p": [
                         "This command will automatically create a folder in your <code>content/</code> directory with the",
-                        "Type name, a <code>_blueprint.json</code> file inside that folder that describes the Type's field",
-                        "structure, and a corresponding template in <code>layout/content/</code> that has the same name as the Type."
+                        "type name, a <code>_blueprint.json</code> file inside that folder that describes the type's field",
+                        "structure, and a corresponding template in <code>layout/content/</code> that has the same name as the type."
                     ]
                 }
             ]
@@ -35,7 +35,7 @@
                             [
                                 "<code>--endpoint=true</code>",
                                 "<code>-e=true</code>",
-                                "Pass \"false\" if you don't want your new Type to have an endpoint that site visitors can access directly"
+                                "Pass \"false\" if you don't want your new type to have an endpoint that site visitors can access directly"
                             ]
                         ]
                     }

--- a/content/docs/paths.json
+++ b/content/docs/paths.json
@@ -8,7 +8,7 @@
             "body": [
                 {
                     "p": [
-                        "The endpoint nodes for your pages (of whatever Type) will be defined by your data source.",
+                        "The endpoint nodes for your pages (of whatever type) will be defined by your data source.",
                         "By default this corresponds to the structure of folders and files in your <code>content/</code> folder,",
                         "for example:<ul>",
                         "<li><code>content/index.json</code> = <code>https://example.com/</code></li>",
@@ -31,7 +31,7 @@
                 {
                     "p": [
                         "You can overide the default path structure in the site's configuration file (<code>plenti.json</code>).",
-                        "For example if you had a Type called <code>pages</code> and you wanted it to appear at the top level of the",
+                        "For example if you had a type called <code>pages</code> and you wanted it to appear at the top level of the",
                         "site and not in the format <code>https://example.com/pages/page1</code>, you could add the following to <code>plenti.json</code>:",
                         "<br /><br /><codeblock>\"types\": {<br />&nbsp;&nbsp;\"pages\": \"/:filename\"<br />}</codeblock>",
                         "This would allow a content file located at <code>content/pages/page1.json</code> to appear in the following format: <code>https://example.com/page1</code>."
@@ -39,7 +39,7 @@
                 },
                 {
                     "p": [
-                        "You can use any custom key that you define in your content source, e.g. <code>:title</code>, <code>:date</code>, etc in your path, for example:",
+                        "You can use any custom key that you define in your content source, e.g. <code>:title</code>, <code>:date</code>, etc. in your path, for example:",
                         "<br /><br /><codeblock>\"types\": {<br />&nbsp;&nbsp;\"blog\": \"/blog/:field(author)/:field(title)\"<br />}"
                     ]
                 }

--- a/content/docs/types.json
+++ b/content/docs/types.json
@@ -38,11 +38,11 @@
             "body": [
                 {
                     "p": [
-                        "There is an optional, special named file that goes inside your individual type folders named <code>_blueprint.json</code>.",
+                        "There is an optional, specially named file that goes inside your individual type folders named <code>_blueprint.json</code>.",
                         "This defines the default field schema for that specific type.",
                         "The keys of the blueprint correspond to field names used in the content files and the values tell the kind of field that is being used.",
                         "<strong>TODO:</strong> Currently the blueprint doesn't do much and there is no list of standardized values, but in the future this will",
-                        "be fleshed out and it will aid in generating scaffoling and tying into the cms (see <a href='https://github.com/plentico/plenti/issues/15'>this issue</a>)."
+                        "be fleshed out and it will aid in generating scaffolding and tying into the CMS (see <a href='https://github.com/plentico/plenti/issues/15'>this issue</a>)."
                     ]
                 }
             ]


### PR DESCRIPTION
The existing content is inconsistent in its treatment of the term `type`. This PR lowercases almost all uses except where English grammar rules apply.

This subject - akin to tabs vs spaces - can be prone to useless debate, so I put this in its own PR.  

As a research step, I checked how the team behind TypeScript handles the term in their introductory docs: lowercase.  As a Svelte/JavaScript guy that's compelling enough for me.

At the very least the Plenti content ought to be consistent in its use. :)